### PR TITLE
Raise if not using Python 2 in generate.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The top level language under the `catalogue` directory defines the language labe
 
 ## Generating
 
-Run `python generate.py`. This creates a `catalogue.json`. The JSON file is refenced in `index.html` to generate the site.
+Run `python generate.py` (uses Python 2). This creates a `catalogue.json`. The JSON file is refenced in `index.html` to generate the site.
 
 ## Examples
 

--- a/generate.py
+++ b/generate.py
@@ -217,5 +217,10 @@ def main():
     with open("catalogue.json", "w") as outfile:
         json.dump(catalogue, outfile, indent=2)
 
+def check_python_version():
+    if sys.version_info[0] != 2:
+        raise Exception("Must be using Python 2")
+
 if __name__ == "__main__":
+    check_python_version()
     main()


### PR DESCRIPTION
Hi,

I was getting this error re-generating the docs:

```
Traceback (most recent call last):
  File "generate.py", line 221, in <module>
    main()
  File "generate.py", line 214, in main
    _, catalogue = parse_directory(path, 0, "undefined language")
  File "generate.py", line 187, in parse_directory
    succeed, doc = parse_directory(os.path.join(path, subdir), level + 1, language)
  File "generate.py", line 187, in parse_directory
    succeed, doc = parse_directory(os.path.join(path, subdir), level + 1, language)
  File "generate.py", line 187, in parse_directory
    succeed, doc = parse_directory(os.path.join(path, subdir), level + 1, language)
  File "generate.py", line 181, in parse_directory
    entry = process_leaf(path, files, subdirs, language)
  File "generate.py", line 164, in process_leaf
    entry["doc"] = generate_entry_doc(language, doc, path, files)
  File "generate.py", line 112, in generate_entry_doc
    source, diff = read_source_and_diff(path, files)
  File "generate.py", line 80, in read_source_and_diff
    source = source[0]
TypeError: 'filter' object is not subscriptable
```

I'm not a Pythonista so it took me a few minutes to realize the script was written for Python 2, while I'm typically running Python 3.

I added a simple version check with message and updated the README, to reduce future confusion.

Thanks!