### PR TITLE
Make generate.py compatible with Python 3

### DIFF
--- a/catalogue/Python2/modernize-filter/DOC.md
+++ b/catalogue/Python2/modernize-filter/DOC.md
@@ -4,4 +4,3 @@
 **Id:** python2-lambda-filter-to-list
 **Tags:** ["Compatibility"]
 **Known problems:** Should break Python 3 programs if applied, because there filter() returns a generator.
-

--- a/catalogue/Python2/modernize-filter/DOC.md
+++ b/catalogue/Python2/modernize-filter/DOC.md
@@ -1,0 +1,7 @@
+**What it does:** Replaces `lambda` + `filter` usage with list comprehensions compatible with Python 3.
+**Reference:** See [python-modernize](https://github.com/python-modernize/python-modernize) for problem description and [filter() in Python 2](https://docs.python.org/2/library/functions.html#filter) documentation.
+**Author:** Anonymous
+**Id:** python2-lambda-filter-to-list
+**Tags:** ["Compatibility"]
+**Known problems:** Should break Python 3 programs if applied, because there filter() returns a generator.
+

--- a/catalogue/Python2/modernize-filter/match
+++ b/catalogue/Python2/modernize-filter/match
@@ -1,0 +1,1 @@
+filter(lambda :[[arg]]: :[condition], :[[target]])

--- a/catalogue/Python2/modernize-filter/rewrite
+++ b/catalogue/Python2/modernize-filter/rewrite
@@ -1,0 +1,1 @@
+[:[arg] for :[arg] in :[target] if :[condition]]

--- a/catalogue/Python2/modernize-filter/source.py
+++ b/catalogue/Python2/modernize-filter/source.py
@@ -1,0 +1,8 @@
+def read_source_and_diff(path, files):
+    sources = filter(lambda x: x.startswith("source"), files)
+    source = filter(lambda x: not x.endswith("diff"), sources)
+    if source != []:
+        source = source[0]
+    else:
+        print("No source file in {}, please add one.".format(path))
+        sys.exit(1)

--- a/generate.py
+++ b/generate.py
@@ -74,8 +74,8 @@ def generate_diff_file(path, source):
 
 
 def read_source_and_diff(path, files):
-    sources = filter(lambda x: x.startswith("source"), files)
-    source = filter(lambda x: not x.endswith("diff"), sources)
+    sources = [x for x in files if x.startswith("source")]
+    source = [x for x in sources if not x.endswith("diff")]
     if source != []:
         source = source[0]
     else:

--- a/generate.py
+++ b/generate.py
@@ -14,15 +14,16 @@ def parse_doc_markdown(doc_file_path):
     doc_md = defaultdict(lambda: "[]")
     doc_line = re.compile(r'''^\*\*([\w\s]+?)[:?.!]?\*\*(.*)''')
     with open(doc_file_path) as doc_file_path:
-        for line in doc_file_path:
+        for idx, line in enumerate(doc_file_path):
             match = re.match(doc_line, line)
             if match:
                 heading = match.groups()[0].lstrip()
                 text = match.groups()[1].lstrip()
                 doc_md[heading] = text
             else:
-                print ("Bad doc.md format in {}".format(doc_file_path))
-                os.exit(1)
+                print("Bad doc.md format in {}".format(doc_file_path))
+                print("Line no.{} didn't match:\n{}".format(idx+1, line))
+                sys.exit(1)
         tags = doc_md["Tags"]
         doc_md["Tags"] = eval(tags)
     return doc_md

--- a/generate.py
+++ b/generate.py
@@ -68,9 +68,9 @@ def generate_diff_file(path, source):
     print("Running: {}".format(command))
     diff = subprocess.check_output(command, shell=True)
     _ = subprocess.check_output("git checkout -- {}".format(os.path.join(path, source)), shell=True)
-    diff = '\n'.join((diff.split('\n')[5:]))
+    diff = b'\n'.join((diff.split(b'\n')[5:]))
     diff_out_path = os.path.join(path, "source.diff")
-    with open(diff_out_path, "w") as outfile:
+    with open(diff_out_path, "wb") as outfile:
         outfile.write(diff)
 
 
@@ -218,10 +218,5 @@ def main():
     with open("catalogue.json", "w") as outfile:
         json.dump(catalogue, outfile, indent=2)
 
-def check_python_version():
-    if sys.version_info[0] != 2:
-        raise Exception("Must be using Python 2")
-
 if __name__ == "__main__":
-    check_python_version()
     main()

--- a/generate.py
+++ b/generate.py
@@ -6,7 +6,7 @@ import sys
 import os
 import subprocess
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
 comby_path = "comby"
 
@@ -156,15 +156,15 @@ def generate_live_json(language, path, files):
 
 def process_leaf(path, files, subdirs, language):
     leaf = "DOC.md" in files and "match" in files and "rewrite" in files
-    entry = {}
+    entry = OrderedDict()
     parent = os.path.basename(path)
     if leaf:
         doc = parse_doc_markdown(os.path.join(path, "DOC.md"))
-        entry["tags"] = doc["Tags"]
-        entry["language"] = language
         entry["doc"] = generate_entry_doc(language, doc, path, files)
-        entry["name"] = parent
         entry["live"] = generate_live_json(language, path, files)
+        entry["name"] = parent
+        entry["language"] = language
+        entry["tags"] = doc["Tags"]
         return entry
     else: # TODO
         return {}


### PR DESCRIPTION
I used docker image to produce the patch using new template.

    ./02cowrite.sh -templates /opt/catalogue/Python2 -d /opt -f generate.py -in-place

The content of `02cowrite.sh`.

    #!/bin/bash

    podman run --rm -i -a stdin -a stdout -a stderr -v "$(pwd)":/opt:Z comby/comby "$@"